### PR TITLE
Add support for Django 1.10

### DIFF
--- a/db_multitenant/db/backends/mysql/base.py
+++ b/db_multitenant/db/backends/mysql/base.py
@@ -23,11 +23,15 @@
 
 import logging
 import time
+import sys
 
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.importlib import import_module
 from db_multitenant.threadlocal import MultiTenantThreadlocal
-
+if sys.version_info < (2, 7) :
+    from django.utils.importlib import import_module
+else:
+    from importlib import import_module
+    
 WRAPPED_BACKEND = import_module('django.db.backends.mysql.base')
 
 LOGGER = logging.getLogger('db_multitenant')

--- a/db_multitenant/db/backends/mysql/base.py
+++ b/db_multitenant/db/backends/mysql/base.py
@@ -26,11 +26,13 @@ import time
 import sys
 
 from django.core.exceptions import ImproperlyConfigured
-from db_multitenant.threadlocal import MultiTenantThreadlocal
 if sys.version_info < (2, 7) :
     from django.utils.importlib import import_module
 else:
     from importlib import import_module
+    
+from db_multitenant.threadlocal import MultiTenantThreadlocal
+from db_multitenant.utils import update_database_from_env
     
 WRAPPED_BACKEND = import_module('django.db.backends.mysql.base')
 
@@ -54,7 +56,12 @@ class DatabaseWrapper(WRAPPED_BACKEND.DatabaseWrapper):
 
         dbname = self.threadlocal.get_dbname()
         if not dbname:
-            raise ImproperlyConfigured('dbname not set at cursor create time')
+            # Django loads the settings after it tries to connect to mysql, when running management commands
+            # If that's the case, update database name manually
+            update_database_from_env(super(DatabaseWrapper, self).get_connection_params())
+            dbname = self.threadlocal.get_dbname()
+            if not dbname:
+                raise ImproperlyConfigured('dbname not set at cursor create time')
 
         # Cache the applied dbname as "mt_dbname" on the connection, avoiding
         # an extra execute() if already set.  Importantly, we assume no other

--- a/db_multitenant/middleware.py
+++ b/db_multitenant/middleware.py
@@ -23,10 +23,16 @@
 
 from django.conf import settings
 from django.db import connection
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    # Not required for Django <= 1.9, see:
+    # https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware
+    MiddlewareMixin = object
 
 from db_multitenant import utils
 
-class MultiTenantMiddleware(object):
+class MultiTenantMiddleware(MiddlewareMixin):
     """Should be placed first in your middlewares.
 
     This middleware sets up the database and cache prefix from the request."""

--- a/db_multitenant/utils.py
+++ b/db_multitenant/utils.py
@@ -20,10 +20,14 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import sys
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.importlib import import_module
+if sys.version_info < (2, 7) :
+    from django.utils.importlib import import_module
+else:
+    from importlib import import_module
 
 from db_multitenant.mapper import TenantMapper
 


### PR DESCRIPTION
Replaces obsolete imports and updates middleware style while maintaining backward compatibility.
Also fixes support for management commands as suggested by [AlexvEck](https://github.com/mik3y/django-db-multitenant/issues/6).